### PR TITLE
Feature/cm 310 blob constructor functional test

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/MainActivity.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/MainActivity.cs
@@ -32,6 +32,11 @@ namespace Couchbase.Lite.Testing.Android
             var tmpDir = ApplicationContext.CacheDir.AbsolutePath;
             var finalPath = Path.Combine(tmpDir, "tmp");
 
+            if (System.IO.File.Exists(finalPath))
+            {
+                System.IO.File.Delete(finalPath);
+            }
+
             // Copy zip file out of the app bundle and into a temporary directory
             using (var input = ApplicationContext.Assets.Open(path))
             {

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/BlobMethods.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/BlobMethods.cs
@@ -62,7 +62,7 @@ namespace Couchbase.Lite.Testing
             #endregion
         }
 
-        public static void CreateImageContent([NotNull] NameValueCollection args,
+        public static void CreateImageStream([NotNull] NameValueCollection args,
             [NotNull] IReadOnlyDictionary<string, object> postBody,
             [NotNull] HttpListenerResponse response)
         {
@@ -72,7 +72,7 @@ namespace Couchbase.Lite.Testing
             response.WriteBody(MemoryMap.Store(stream));
         }
 
-        public static void CreateImageByteArray([NotNull] NameValueCollection args,
+        public static void CreateImageContent([NotNull] NameValueCollection args,
             [NotNull] IReadOnlyDictionary<string, object> postBody,
             [NotNull] HttpListenerResponse response)
         {
@@ -87,11 +87,8 @@ namespace Couchbase.Lite.Testing
             [NotNull] HttpListenerResponse response)
         {
             string imageLocation = TestServer.FilePathResolver(postBody["image"].ToString(), false);
-            string filePath = TestServer.FilePathResolver(postBody["image"].ToString(), true);
-
             
-
-            Uri fileUrl = new Uri(filePath);
+            Uri fileUrl = new Uri(imageLocation);
             response.WriteBody(MemoryMap.Store(fileUrl));
         }
 

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/BlobMethods.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/BlobMethods.cs
@@ -43,21 +43,21 @@ namespace Couchbase.Lite.Testing
             [NotNull] HttpListenerResponse response)
         {
             var contentType = postBody["contentType"].ToString();
-            Stream stream = MemoryMap.Get<Stream>(postBody["stream"].ToString());
             if (postBody.ContainsKey("content"))
             {
-                response.WriteBody(MemoryMap.New<Blob>(contentType, postBody["content"]));
+                byte[] byteArray = MemoryMap.Get<byte[]>(postBody["content"].ToString());
+                response.WriteBody(MemoryMap.New<Blob>(contentType, byteArray));
             }
             else if (postBody.ContainsKey("stream"))
             {
-
+                Stream stream = MemoryMap.Get<Stream>(postBody["stream"].ToString());
                 response.WriteBody(MemoryMap.New<Blob>(contentType, stream));
             }
 
             else if (postBody.ContainsKey("fileURL"))
             {
-
-                response.WriteBody(MemoryMap.New<Blob>(contentType, postBody["fileURL"]));
+                Uri fileUri = MemoryMap.Get<Uri>(postBody["fileURL"].ToString());
+                response.WriteBody(MemoryMap.New<Blob>(contentType, fileUri));
             }
             #endregion
         }
@@ -66,13 +66,33 @@ namespace Couchbase.Lite.Testing
             [NotNull] IReadOnlyDictionary<string, object> postBody,
             [NotNull] HttpListenerResponse response)
         {
-
             string imageLocation = TestServer.FilePathResolver(postBody["image"].ToString(), false);
             var image = File.ReadAllBytes(imageLocation);
             MemoryStream stream = new MemoryStream(image);
             response.WriteBody(MemoryMap.Store(stream));
+        }
 
+        public static void CreateImageByteArray([NotNull] NameValueCollection args,
+            [NotNull] IReadOnlyDictionary<string, object> postBody,
+            [NotNull] HttpListenerResponse response)
+        {
+            string imageLocation = TestServer.FilePathResolver(postBody["image"].ToString(), false);
+            var image = File.ReadAllBytes(imageLocation);
+            MemoryStream stream = new MemoryStream(image);
+            response.WriteBody(MemoryMap.Store(stream.ToArray()));
+        }
 
+        public static void CreateImageFileUrl([NotNull] NameValueCollection args,
+            [NotNull] IReadOnlyDictionary<string, object> postBody,
+            [NotNull] HttpListenerResponse response)
+        {
+            string imageLocation = TestServer.FilePathResolver(postBody["image"].ToString(), false);
+            string filePath = TestServer.FilePathResolver(postBody["image"].ToString(), true);
+
+            
+
+            Uri fileUrl = new Uri(filePath);
+            response.WriteBody(MemoryMap.Store(fileUrl));
         }
 
         public static void Digest([NotNull] NameValueCollection args,

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
@@ -260,6 +260,8 @@ namespace Couchbase.Lite.Testing
                 ["logging_getLogsInZip"] = FileLoggingMehtod.GetLogsInZip,
                 ["blob_create"] = BlobMethods.Create,
                 ["blob_createImageContent"] = BlobMethods.CreateImageContent,
+                ["blob_createImageByteArray"] = BlobMethods.CreateImageByteArray,
+                ["blob_createImageFileUrl"] = BlobMethods.CreateImageFileUrl,
                 ["blob_digest"] = BlobMethods.Digest,
                 ["blob_equals"] = BlobMethods.Equals,
                 ["blob_getContent"] = BlobMethods.GetContent,

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer/Router.cs
@@ -260,7 +260,7 @@ namespace Couchbase.Lite.Testing
                 ["logging_getLogsInZip"] = FileLoggingMehtod.GetLogsInZip,
                 ["blob_create"] = BlobMethods.Create,
                 ["blob_createImageContent"] = BlobMethods.CreateImageContent,
-                ["blob_createImageByteArray"] = BlobMethods.CreateImageByteArray,
+                ["blob_createImageStream"] = BlobMethods.CreateImageStream,
                 ["blob_createImageFileUrl"] = BlobMethods.CreateImageFileUrl,
                 ["blob_digest"] = BlobMethods.Digest,
                 ["blob_equals"] = BlobMethods.Equals,

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/BlobRequestHandler.swift
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Server/BlobRequestHandler.swift
@@ -22,11 +22,11 @@ public class BlobRequestHandler {
         //////////
         case "blob_create":
             let contentType: String = args.get(name: "contentType")!
-            let content: Data = args.get(name: "content")!
+            let content: Data? = args.get(name: "content")
             let stream: InputStream? = args.get(name: "stream")!
             let fileURL: URL? = args.get(name: "fileURL")!
-            if (!content.isEmpty){
-                return Blob(contentType: contentType, data: content)
+            if (content != nil){
+                return Blob(contentType: contentType, data: content!)
             } else if (stream != nil){
                 return Blob(contentType: contentType, contentStream: stream!)
             } else if (fileURL != nil){
@@ -40,6 +40,19 @@ public class BlobRequestHandler {
             let appleImage = UIImage(named: image)!
             let imageData = UIImageJPEGRepresentation(appleImage, 1)!
             return imageData
+            
+        case "blob_createImageStream":
+            let image: String = args.get(name: "image")!
+            let appleImage = UIImage(named: image)!
+            let imageData = UIImageJPEGRepresentation(appleImage, 1)!
+            
+            return InputStream(data: imageData)
+            
+        case "blob_createImageFileUrl":
+            let image: String = args.get(name: "image")!
+            let urlPath = Bundle.main.url(forResource: image, withExtension: "")
+            
+            return urlPath
             
         case "blob_digest":
             let blob: Blob = args.get(name: "blob")!

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
@@ -1,13 +1,20 @@
 package com.couchbase.mobiletestkit.javacommon.RequestHandler;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
 import com.couchbase.mobiletestkit.javacommon.Args;
 import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
 import com.couchbase.lite.Blob;
+import com.couchbase.lite.utils.FileUtils;
+import com.couchbase.mobiletestkit.javacommon.util.ZipUtils;
 
 
 public class BlobRequestHandler {
@@ -35,6 +42,39 @@ public class BlobRequestHandler {
 
         String[] imgFilePath = filePath.split("/");
         return RequestHandlerDispatcher.context.getAsset(imgFilePath[imgFilePath.length - 1]);
+    }
+
+    public byte[] createImageByteArray(Args args) throws IOException {
+        String filePath = args.get("image");
+        if (filePath == null || filePath.isEmpty()) {
+            throw new IOException("Image content file path cannot be null");
+        }
+
+        String[] imgFilePath = filePath.split("/");
+        InputStream stream = RequestHandlerDispatcher.context.getAsset(imgFilePath[imgFilePath.length - 1]);
+        byte[] targetArray = new byte[stream.available()];
+        stream.read(targetArray);
+
+        return targetArray;
+    }
+
+    public URL createImageFileUrl(Args args) throws IOException, MalformedURLException {
+        String filePath = args.get("image");
+        if (filePath == null || filePath.isEmpty()) {
+            throw new IOException("Image content file path cannot be null");
+        }
+
+        String[] imgFilePath = filePath.split("/");
+        String imgFileName = imgFilePath[imgFilePath.length - 1];
+        InputStream stream = RequestHandlerDispatcher.context.getAsset(imgFileName);
+
+        String directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath();
+        File targetFile = new File(directory, imgFileName);
+        OutputStream outStream = new FileOutputStream(targetFile);
+        ZipUtils utils = new ZipUtils();
+        utils.copyFile(stream, outStream);
+
+        return targetFile.toURI().toURL();
     }
 
     public String digest(Args args) {

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
@@ -34,7 +34,7 @@ public class BlobRequestHandler {
         throw new IOException("Incorrect parameters provided");
     }
 
-    public InputStream createImageContent(Args args) throws IOException {
+    public InputStream createImageStream(Args args) throws IOException {
         String filePath = args.get("image");
         if (filePath == null || filePath.isEmpty()) {
             throw new IOException("Image content file path cannot be null");
@@ -44,7 +44,7 @@ public class BlobRequestHandler {
         return RequestHandlerDispatcher.context.getAsset(imgFilePath[imgFilePath.length - 1]);
     }
 
-    public byte[] createImageByteArray(Args args) throws IOException {
+    public byte[] createImageContent(Args args) throws IOException {
         String filePath = args.get("image");
         if (filePath == null || filePath.isEmpty()) {
             throw new IOException("Image content file path cannot be null");

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
@@ -40,8 +40,7 @@ public class BlobRequestHandler {
             throw new IOException("Image content file path cannot be null");
         }
 
-        String[] imgFilePath = filePath.split("/");
-        return RequestHandlerDispatcher.context.getAsset(imgFilePath[imgFilePath.length - 1]);
+        return RequestHandlerDispatcher.context.getAsset(filePath);
     }
 
     public byte[] createImageContent(Args args) throws IOException {
@@ -50,8 +49,7 @@ public class BlobRequestHandler {
             throw new IOException("Image content file path cannot be null");
         }
 
-        String[] imgFilePath = filePath.split("/");
-        InputStream stream = RequestHandlerDispatcher.context.getAsset(imgFilePath[imgFilePath.length - 1]);
+        InputStream stream = RequestHandlerDispatcher.context.getAsset(filePath);
         byte[] targetArray = new byte[stream.available()];
         stream.read(targetArray);
 
@@ -64,12 +62,10 @@ public class BlobRequestHandler {
             throw new IOException("Image content file path cannot be null");
         }
 
-        String[] imgFilePath = filePath.split("/");
-        String imgFileName = imgFilePath[imgFilePath.length - 1];
-        InputStream stream = RequestHandlerDispatcher.context.getAsset(imgFileName);
+        InputStream stream = RequestHandlerDispatcher.context.getAsset(filePath);
 
         String directory = RequestHandlerDispatcher.context.getFilesDir().getAbsolutePath();
-        File targetFile = new File(directory, imgFileName);
+        File targetFile = new File(directory, filePath);
         OutputStream outStream = new FileOutputStream(targetFile);
         ZipUtils utils = new ZipUtils();
         utils.copyFile(stream, outStream);

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/util/ZipUtils.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/util/ZipUtils.java
@@ -122,7 +122,7 @@ public class ZipUtils {
         }
     }
 
-    private void copyFile(InputStream in, OutputStream out) throws IOException {
+    public void copyFile(InputStream in, OutputStream out) throws IOException {
         int len;
         while ((len = in.read(buffer)) > 0) { out.write(buffer, 0, len); }
     }


### PR DESCRIPTION
Add Blob constructor support to the TestServer app.

1. added correspondent methods to create a blob object through all 3 overloaded constructors
2. added support in .net/android-java/iOS
3. fixed a few issues and naming problems