### PR TITLE
fix the setAuthenticator issue

### DIFF
--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorConfigurationRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/ReplicatorConfigurationRequestHandler.java
@@ -107,7 +107,9 @@ public class ReplicatorConfigurationRequestHandler {
         if (headers != null) {
             config.setHeaders(headers);
         }
-        config.setAuthenticator(authenticator);
+        if (authenticator != null) {
+            config.setAuthenticator(authenticator);
+        }
         config.setReplicatorType(replType);
         /*if (conflictResolver != null) {
             config.setConflictResolver(conflictResolver);


### PR DESCRIPTION
authenticator is not allowed null. this fix will get rid of test issues where authenticator object is not set, but session header is used.

the fix is for android, verified DotNet and iOS platforms, they seem already have the not null check, so no additional fix needs to be done on those 2 platforms.