### PR TITLE
fix 2 build issues, gradle issue after tool chain upgrade, and litecore namespace change…

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Android/app/build.gradle
+++ b/CBLClient/Apps/CBLTestServer-Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 ext {
-    DEF_VERSION = "2.8.0-203"
+    DEF_VERSION = "2.8.0-204"
     COUCHBASE_LITE_VERSION = System.getProperty('version', DEF_VERSION)
 
     PROJECT_DIR = "${projectDir}"
@@ -14,6 +14,7 @@ ext {
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
+    ndkVersion "21.2.6472646"
 
     defaultConfig {
         applicationId "com.couchbase.TestServerApp"
@@ -75,6 +76,7 @@ repositories {
 
 dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    //noinspection GradleCompatible
     implementation 'com.android.support:appcompat-v7:28.0.0'
 
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/BlobRequestHandler.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import com.couchbase.mobiletestkit.javacommon.Args;
 import com.couchbase.mobiletestkit.javacommon.RequestHandlerDispatcher;
 import com.couchbase.lite.Blob;
-import com.couchbase.lite.utils.FileUtils;
 import com.couchbase.mobiletestkit.javacommon.util.ZipUtils;
 
 


### PR DESCRIPTION
problem 1: 
gradle has a bug to assign an NDK version to a project which doesn't require NDK of course no NDK specified. Due the build environment has other than gradle expected NDK version installed, it fails the build.
solution: specify an NDK version which is installed on the build environment, it doesn't harm testserver app build, in this case, we don't need to mess up the build machine environment.

problem 2:
CBLite android sounds removed a namespace: com.couchbase.lite.utils.FileUtils
solution: get rid of the removed namespace, testserver app still builds successfully without this namespace.