### PR TITLE
fix a build location issue in ios build script

### DIFF
--- a/CBLClient/Apps/CBLTestServer-iOS/build_ios_testserver_app.sh
+++ b/CBLClient/Apps/CBLTestServer-iOS/build_ios_testserver_app.sh
@@ -3,7 +3,7 @@
 EDITION=$1
 VERSION=$2
 BLD_NUM=$3
-cd ${WORKSPACE}/mobile-testkit/CBLClient/Apps/CBLTestServer-iOS
+cd ${WORKSPACE}/mobile-testapps/CBLClient/Apps/CBLTestServer-iOS
 brew install carthage
 carthage update
 if [[ ! -d Frameworks ]]; then mkdir Frameworks; fi
@@ -17,7 +17,7 @@ SCHEME=CBLTestServer-iOS-EE
 fi
 SDK=iphonesimulator
 SDK_DEVICE=iphoneos
-FRAMEWORK_DIR=${WORKSPACE}/mobile-testkit/CBLClient/Apps/CBLTestServer-iOS/Frameworks
+FRAMEWORK_DIR=${WORKSPACE}/mobile-testapps/CBLClient/Apps/CBLTestServer-iOS/Frameworks
 
 if [[ -d build ]]; then rm -rf build/*; fi
 if [[ -d ${FRAMEWORK_DIR} ]]; then rm -rf ${FRAMEWORK_DIR}/*; fi


### PR DESCRIPTION
the build script need to pointing to a correct directory to ensure test app build with the right source code