### PR TITLE
add back the getLogLevel function, fix the test app code

### DIFF
--- a/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/LoggingRequestHandler.java
+++ b/CBLClient/Apps/JavaRequestHandlers/src/main/java/com/couchbase/mobiletestkit/javacommon/RequestHandler/LoggingRequestHandler.java
@@ -114,6 +114,10 @@ public class LoggingRequestHandler {
         return config;
     }
 
+    public int getLogLevel(Args args) {
+        return Database.log.getFile().getLevel().ordinal();
+    }
+
     public LogFileConfiguration setLogLevel(Args args) {
         LogFileConfiguration config = args.get("config");
         String log_level = args.get("log_level");


### PR DESCRIPTION
LogLevel CBLite implementation for Java/Android has removed the "get" method as part of 3.0 code changes, directly calling getLogLevel() will fail in TestServer app, due to method no longer exists. 

Call LogLevel ordinal() to get integer value of LogLevel enum.