### PR TITLE
fix dotnet app build

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Couchbase.Lite.Enterprise.Support.Android">
-      <Version>2.7.0-b0001</Version>
+      <Version>2.8.4-b0007</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
@@ -48,6 +48,11 @@
     <AndroidSupportedAbis>x86;arm64-v8a;x86_64;armeabi-v7a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Couchbase.Lite.Enterprise.Support.Android">
+      <Version>2.7.0-b0001</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.Android/TestServer.Android.csproj
@@ -88,6 +88,9 @@
       <Project>{ca1db44f-9a07-40c1-b305-f0b5d797ee6a}</Project>
       <Name>TestServer</Name>
     </ProjectReference>
+    <PackageReference Include="SimpleInjector">
+      <Version>5.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\PrebuiltDB.cblite2.zip" />

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.UWP/TestServer.UWP.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.UWP/TestServer.UWP.csproj
@@ -148,6 +148,9 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="Assets\certs\certs.p12" />
+    <Content Include="Assets\certs\client.p12" />
+    <Content Include="Assets\certs\client-ca.der" />
     <Content Include="Properties\Default.rd.xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Included  UWP tls certs in common property list too
And xamarin - android intermittently required the version property 

http://uberjenkins.sc.couchbase.com:8080/view/p2p/job/CBLITE_UWP-p2p-dotnet/4/

http://mobile.jenkins.couchbase.com/view/CBL%202.x/job/couchbase-lite-net-testapp/283/