### PR TITLE
Fixed the launching of the UWP and .net

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.NetCore/TestServer.NetCore.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.NetCore/TestServer.NetCore.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>default</LangVersion>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
@@ -19,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TestServer\TestServer.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SimpleInjector" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.UWP/TestServer.UWP.csproj
+++ b/CBLClient/Apps/CBLTestServer-Dotnet/TestServer.UWP/TestServer.UWP.csproj
@@ -178,6 +178,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SimpleInjector" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <BundleResource Include="Assets\certs\certs.p12" />
     <BundleResource Include="Assets\certs\client.p12" />
     <BundleResource Include="Assets\certs\client-ca.der" />


### PR DESCRIPTION
As we upgrade the netapp2.1 to 3.1 , we have to upgrade the  netapp run times on every .net lite server hosts.
I have upgraded the sdk and netapp on all .net windows vm
Also we need these dependencies for netapp runtime    http://mobile.jenkins.couchbase.com/view/CBL%202.x/job/couchbase-lite-net-testapp/318/