### PR TITLE
Update build_cross.py

### DIFF
--- a/CBLClient/Apps/CBLTestServer-C/build_scripts/build_cross.py
+++ b/CBLClient/Apps/CBLTestServer-C/build_scripts/build_cross.py
@@ -146,6 +146,7 @@ if __name__ == '__main__':
     os.chdir(DOWNLOAD_DIR)
 
     print(f"==== Downloading Couchbase Lite C [{args.os}] {args.version}-{args.bld_num} ====")
+    build_system = args.os
     os_x86_64_list = ["debian9-x86_64", "debian10-x86_64", "ubuntu20.04_x64", "raspbian9"]
     if args.os in os_x86_64_list:
         build_system = "linux-x86_64"

--- a/CBLClient/Apps/CBLTestServer-C/build_scripts/build_cross.py
+++ b/CBLClient/Apps/CBLTestServer-C/build_scripts/build_cross.py
@@ -146,7 +146,10 @@ if __name__ == '__main__':
     os.chdir(DOWNLOAD_DIR)
 
     print(f"==== Downloading Couchbase Lite C [{args.os}] {args.version}-{args.bld_num} ====")
-    zip_filename=f'couchbase-lite-c-{args.edition}-{args.version}-{args.bld_num}-{args.os}.tar.gz'
+    os_x86_64_list = ["debian9-x86_64", "debian10-x86_64", "ubuntu20.04_x64", "raspbian9"]
+    if args.os in os_x86_64_list:
+        build_system = "linux-x86_64"
+    zip_filename=f'couchbase-lite-c-{args.edition}-{args.version}-{args.bld_num}-{build_system}.tar.gz'
     urllib.request.urlretrieve(f'http://latestbuilds.service.couchbase.com/builds/latestbuilds/couchbase-lite-c/{args.version}/{args.bld_num}/{zip_filename}', zip_filename, show_download_progress)
     with tarfile.open(zip_filename, 'r:gz') as tar:
         tar.extractall(DOWNLOAD_DIR)


### PR DESCRIPTION
Changing the build script for x86_64 based system in C build_cross.py.
Will add changes for different architecture-based systems.