### PR TITLE
Disable NSAllowsArbitraryLoads

### DIFF
--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -42,6 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSAllowsArbitraryLoads</key>
-	<string>No</string>	
+	<string>Yes</string>
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -42,5 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
+        <string>Exchange data with nearby devices running the Yourapp.</string>
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -41,7 +41,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSLocalNetworkUsageDescription</key>
-        <string>Exchange data with nearby devices running the Yourapp.</string>
+	<key>NSAllowsArbitraryLoads</key>
+        <string>No</string>
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -41,7 +41,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSAllowsArbitraryLoads</key>
-	<string>No</string>
+	<key>NSLocalNetworkUsageDescription</key>
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -41,5 +41,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAllowsArbitraryLoads</key>
+	<string>Yes</string>	
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -42,6 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSAllowsArbitraryLoads</key>
-	<string>Yes</string>	
+	<string>No</string>	
 </dict>
 </plist>

--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -42,6 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSAllowsArbitraryLoads</key>
-	<string>Yes</string>
+	<string>No</string>
 </dict>
 </plist>


### PR DESCRIPTION
Updating the test app with this setting, following recent CBL changes.

Tested both on a "new" and "old" phone.