### PR TITLE
Disable the NSAllowsArbitraryLoads

### DIFF
--- a/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
+++ b/CBLClient/Apps/CBLTestServer-iOS/CBLTestServer-iOS/Info.plist
@@ -41,5 +41,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAllowsArbitraryLoads</key>
+	<string>No</string>
 </dict>
 </plist>


### PR DESCRIPTION
Update the NSAllowsArbitraryLoads following recent dev changes.

Tested on a new and old iPhone.