### PR TITLE
Don't release embedding dictionary

### DIFF
--- a/CBLClient/Apps/CBLTestServer-C/src/Router.cpp
+++ b/CBLClient/Apps/CBLTestServer-C/src/Router.cpp
@@ -226,11 +226,13 @@ static const unordered_map<string, endpoint_handler> ROUTE_MAP = {
     {"scope_collection", scope_methods::scope_collection},
     {"scope_collectionNames", scope_methods::scope_collectionNames},
     {"scope_defaultScope", scope_methods::scope_defaultScope},
+    #ifdef COUCHBASE_ENTERPRISE
     {"vectorSearch_createIndex", vectorSearch_methods::vectorSearch_createIndex},
     {"vectorSearch_loadDatabase", vectorSearch_methods::vectorSearch_loadDatabase},
     {"vectorSearch_registerModel", vectorSearch_methods::vectorSearch_registerModel},
     {"vectorSearch_query", vectorSearch_methods::vectorSearch_query},
     {"vectorSearch_getEmbedding", vectorSearch_methods::vectorSearch_getEmbedding},
+    #endif
     {"release", releaseObject},
     {"flushMemory", flushMemory},
 };

--- a/CBLClient/Apps/CBLTestServer-C/src/Router.cpp
+++ b/CBLClient/Apps/CBLTestServer-C/src/Router.cpp
@@ -226,13 +226,11 @@ static const unordered_map<string, endpoint_handler> ROUTE_MAP = {
     {"scope_collection", scope_methods::scope_collection},
     {"scope_collectionNames", scope_methods::scope_collectionNames},
     {"scope_defaultScope", scope_methods::scope_defaultScope},
-    #ifdef COUCHBASE_ENTERPRISE
     {"vectorSearch_createIndex", vectorSearch_methods::vectorSearch_createIndex},
     {"vectorSearch_loadDatabase", vectorSearch_methods::vectorSearch_loadDatabase},
     {"vectorSearch_registerModel", vectorSearch_methods::vectorSearch_registerModel},
     {"vectorSearch_query", vectorSearch_methods::vectorSearch_query},
     {"vectorSearch_getEmbedding", vectorSearch_methods::vectorSearch_getEmbedding},
-    #endif
     {"release", releaseObject},
     {"flushMemory", flushMemory},
 };

--- a/CBLClient/Apps/CBLTestServer-C/src/VectorSearchMethods.cpp
+++ b/CBLClient/Apps/CBLTestServer-C/src/VectorSearchMethods.cpp
@@ -1,3 +1,4 @@
+#ifdef COUCHBASE_ENTERPRISE
 #include "VectorSearchMethods.h"
 #include "MemoryMap.h"
 #include "Router.h"
@@ -34,7 +35,6 @@ FLMutableDict predictFunction(void* context, FLDict input) {
     auto embbedingsVector =  FLMutableArray_New();
     FLMutableDict predictResult =  FLMutableDict_New();
     DEFER {
-        FLMutableDict_Release(predictResult);
         FLMutableArray_Release(embbedingsVector);
     };
     if (inputWord) {
@@ -289,3 +289,4 @@ namespace vectorSearch_methods
     }
 
 }
+#endif

--- a/CBLClient/Apps/CBLTestServer-C/src/VectorSearchMethods.cpp
+++ b/CBLClient/Apps/CBLTestServer-C/src/VectorSearchMethods.cpp
@@ -1,4 +1,3 @@
-#ifdef COUCHBASE_ENTERPRISE
 #include "VectorSearchMethods.h"
 #include "MemoryMap.h"
 #include "Router.h"
@@ -289,4 +288,3 @@ namespace vectorSearch_methods
     }
 
 }
-#endif


### PR DESCRIPTION
Fix a problem with the test app: it was releasing the embedding dictionary before it was returned, causing a test failure. The dictionary is released by CBL.  

Tested with Jenkins. 