### PR TITLE
disable VS

### DIFF
--- a/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
+++ b/CBLClient/Apps/CBLTestServer-Java-Desktop/src/main/java/com/couchbase/mobiletestkit/javatestserver/TestServerMain.java
@@ -131,12 +131,12 @@ public class TestServerMain implements Daemon {
     private void initCouchbaseLite() {
         Log.init(new TestServerLogger());
         CouchbaseLite.init();
-        try {
-            CouchbaseLite.enableVectorSearch();
-        }
-        catch (CouchbaseLiteException e) {
-            Log.i(TAG, "Warning: vector search was not loaded, the vector serach tests are expected to fail");
-        }
+       // try {
+       //     CouchbaseLite.enableVectorSearch();
+       // }
+       // catch (CouchbaseLiteException e) {
+       //     Log.i(TAG, "Warning: vector search was not loaded, the vector serach tests are expected to fail");
+       // }
         Log.i(TAG, "CouchbaseLite is initialized.");
     }
 


### PR DESCRIPTION
The Java VMs need to be updated to Debian before we can include VectorSearch in the tests, because the CentOs host hardware are not supported.

Built and tested in J.enkins